### PR TITLE
Remove superfluous dependency on gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Horizontal Timeline plugin for jQuery",
   "main": "gulpfile.js",
   "dependencies": {
-    "gulp-sass": "^3.1.0"
   },
   "devDependencies": {
     "browser-sync": "^2.18.12",


### PR DESCRIPTION
I haven't done a whole bunch of PRs so I hope this is appropriate.

We're looking into using this plugin in our small project, but we need to keep dependencies at their minimum.

Note that I'm not adding jQuery as a run-time dependency because I assume you had good reasons to omit it.