### PR TITLE
'lt' curves fix

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -2204,7 +2204,7 @@ class Timeline {
                         case /^lt$/i.test( _curveType[_ba] ): // "(_ex,_ey)┌(_sx,_sy)"
                             ctx_relations.moveTo( _sx, _sy )
                             if ( Math.abs( _sx - _ex ) > _radius ) {
-                                ctx_relations.lineTo( _ex - _radius, _sy ) // "─"
+                                ctx_relations.lineTo( _ex + _radius, _sy ) // "─"
                             }
                             if ( Math.abs( _ey - _sy ) > _radius ) {
                                 ctx_relations.quadraticCurveTo( _ex, _sy, _ex, _sy + _radius ) // "┌"


### PR DESCRIPTION
Hi Ka215,

Thanks for your timeline plugin.

I found a bug in the plugin that affects 'lt'  curves:

Expected:

<img width="267" alt="Animis" src="https://user-images.githubusercontent.com/457786/87414109-251a5a00-c5c3-11ea-874f-5904bed9c7f4.png">


Actual (prior to this fix)
<img width="264" alt="Animis" src="https://user-images.githubusercontent.com/457786/87414174-454a1900-c5c3-11ea-97e9-cdda69728265.png">





I haven't figured out how to do a full build yet, but though I'd share the fix in case you find it useful :)

